### PR TITLE
Remove a blank line when a regtype is 'V' and a text object is entire buffer

### DIFF
--- a/autoload/operator/replace.vim
+++ b/autoload/operator/replace.vim
@@ -42,6 +42,14 @@ function! operator#replace#do(motion_wise)  "{{{2
     let original_selection = &g:selection
     let &g:selection = 'inclusive'
     execute 'normal!' '`['.visual_command.'`]"_d'
+
+    " Work around
+    " When regtype is linewise and text object is entire buffer, remove
+    " blank line after pasting
+    if getregtype(register) ==# 'V' && getline(1, '$') == ['']
+        let put_command .= '`[k"_dd'
+    endif
+
     let &g:selection = original_selection
   end
   execute 'normal!' '"'.register.put_command

--- a/t/entire_buffer.vim
+++ b/t/entire_buffer.vim
@@ -1,0 +1,19 @@
+runtime! plugin/operator/*.vim
+
+describe '<Plug>(operator-replace)'
+  before
+    new
+    call setline(1, 'hoge huga poyo')
+  end
+
+  after
+    close!
+  end
+
+  it 'works properly when regtype is V and object is entire buffer'
+    call setreg('s', 'piyo poyo', 'V')
+    execute 'normal' "V\"s\<Plug>(operator-replace)"
+    Expect line('$') == 1
+    Expect getline(1) ==# 'piyo poyo'
+  end
+end


### PR DESCRIPTION
When a regtype is 'V' and the object is entire buffer, a blank line remains at the top of buffer because a buffer of Vim has at least one line for the place of cursor. This problem often occurs when using vim-textobj-entire.

Before text is:

```
hoge huga
```

Then, do:

``` vim
:call setreg('s', 'aaa', 'V') | execute 'normal' "V\"s\<Plug>(operator-replace)"
```

After text is:

```

aaa
```

This commit fixes the issue by dirty workaround.
I've **added** a test case to confirm that the issue is fixed.
