### PR TITLE
Support all cases of virtualedit

### DIFF
--- a/autoload/operator/replace.vim
+++ b/autoload/operator/replace.vim
@@ -34,6 +34,8 @@ function! operator#replace#do(motion_wise)  "{{{2
   \                  ? 'p'
   \                  : 'P')
 
+  let original_virtualedit = &g:virtualedit
+  let &g:virtualedit = ''
   if !s:is_empty_region(getpos("'["), getpos("']"))
     let original_selection = &g:selection
     let &g:selection = 'inclusive'
@@ -41,6 +43,7 @@ function! operator#replace#do(motion_wise)  "{{{2
     let &g:selection = original_selection
   end
   execute 'normal!' '"'.operator#user#register().put_command
+  let &g:virtualedit = original_virtualedit
   return
 endfunction
 

--- a/t/virtualedit.vim
+++ b/t/virtualedit.vim
@@ -1,0 +1,44 @@
+runtime! plugin/operator/*.vim
+
+describe '<Plug>(operator-replace)'
+  before
+    new
+
+    function! b:.go(virtualedit)
+      let original_virtualedit = &g:virtualedit
+      let &g:virtualedit = a:virtualedit
+
+      put ='abcd'
+      let @" = 'xyz'
+      execute 'normal' "viw\<Plug>(operator-replace)e"
+      Expect getline('.') ==# 'xyz'
+
+      let &g:virtualedit = original_virtualedit
+    endfunction
+  end
+
+  after
+    close!
+  end
+
+  it 'works properly with &virtualedit == ""'
+    call b:.go('')
+  end
+
+  it 'works properly with &virtualedit == "block"'
+    call b:.go('block')
+  end
+
+  it 'works properly with &virtualedit == "insert"'
+    call b:.go('insert')
+  end
+
+  it 'works properly with &virtualedit == "all"'
+    call b:.go('all')
+  end
+
+  it 'works properly with &virtualedit == "onemore"'
+    call b:.go('onemore')
+  end
+end
+


### PR DESCRIPTION
I'm using `virtualedit=all` and noticed that when I replace the word at the end of the line there is an unnecessary space.
This PR fixes it.
